### PR TITLE
only kill browsers if any yet running started from Vim

### DIFF
--- a/plugin/vim-live-server.vim
+++ b/plugin/vim-live-server.vim
@@ -36,14 +36,14 @@ function! KillBrowserSync()
         call system(cmd)
         echo "BrowserSync server on port 3000 terminated."
     endif
-    let s:browsersync_counter -= 1
+    if s:browsersync_counter >= 0 | let s:browsersync_counter -= 1 | endif
 endfunction
 
 function! KillBrowserSyncOnPort(port)
     let cmd = "pgrep -f 'browser-sync.*--port=" . a:port . "' | xargs -r kill"
     call system(cmd)
     echo "BrowserSync server on port " . a:port . " terminated."
-    let s:browsersync_counter -= 1
+    if s:browsersync_counter >= 0 | let s:browsersync_counter -= 1 | endif
 endfunction
 
 function! KillAllBrowserSyncInstances()

--- a/plugin/vim-live-server.vim
+++ b/plugin/vim-live-server.vim
@@ -64,13 +64,13 @@ endif
 
 " Live-Server
 if executable('live-server')
-let s:livebrowser_counter = 0
+let s:liveserver_counter = 0
 
 function! StartLiveServer()
     let cmd = "live-server &"
     call system(cmd)
     echo "Live server started in the background."
-    let s:livebrowser_counter += 1
+    let s:liveserver_counter += 1
 endfunction
 
 function! StartLiveServerOnPort(port)
@@ -78,7 +78,7 @@ function! StartLiveServerOnPort(port)
     let cmd = "live-server --port=" . port_num . "&"
     call system(cmd)
     echo "Live Server started in the background on port " . port_num . "."
-    let s:livebrowser_counter += 1
+    let s:liveserver_counter += 1
 endfunction
 
 " Call Commands
@@ -95,20 +95,20 @@ function! KillLiveServer()
         call system(cmd)
         echo "Live Server on port 8080 terminated."
     endif
-    if s:livebrowser_counter > 0 | let s:livebrowser_counter -= 1 | endif
+    if s:liveserver_counter > 0 | let s:liveserver_counter -= 1 | endif
 endfunction
 
 function! KillLiveServerOnPort(port)
     let cmd = "pgrep -f 'live-server.*--port=" . a:port . "' | xargs -r kill"
     call system(cmd)
     echo "Live Server on port " . a:port . " terminated."
-    if s:livebrowser_counter > 0 | let s:livebrowser_counter -= 1 | endif
+    if s:liveserver_counter > 0 | let s:liveserver_counter -= 1 | endif
 endfunction
 
 function! KillAllLiveServerInstances()
     let cmd = "pkill -f 'live-server'"
     call system(cmd)
-    let s:livebrowser_counter = 0
+    let s:liveserver_counter = 0
 endfunction
 
 command! KillLiveServer call KillLiveServer()
@@ -116,7 +116,7 @@ command! -nargs=1 KillLiveServerOnPort call KillLiveServerOnPort(<f-args>)
 
 augroup LiveServerKill
     autocmd!
-    autocmd VimLeave * if s:browsersync_counter > 0 | call KillAllLiveServerInstances() | endif
+    autocmd VimLeave * if s:liveserver_counter > 0 | call KillAllLiveServerInstances() | endif
 augroup END
 endif
 endif

--- a/plugin/vim-live-server.vim
+++ b/plugin/vim-live-server.vim
@@ -4,12 +4,15 @@
 " By Wolandark
 " https://github.com/wolandark/vim-live-server
 
+if executable('browser-sync')
+let s:browsersync_counter = 0
 "Browser-Sync
 function! StartBrowserSync()
     " let cmd = "browser-sync start --no-notify --server --cwd=" . getcwd() . " --files \"*.html, *.css, *.js\" &"
     let cmd = "browser-sync start --no-notify --server --files *.html, *.css, *.js &"
     call system(cmd)
     echo "BrowserSync started in the background."
+    let s:browsersync_counter += 1
 endfunction
 
 function! StartBrowserSyncOnPort(port)
@@ -17,8 +20,13 @@ function! StartBrowserSyncOnPort(port)
     let cmd = "browser-sync start --no-notify --server --cwd=" . getcwd() . " --port=" . port_num . " --files \"*.html, *.css, *.js\" &"
     call system(cmd)
     echo "BrowserSync started in the background on port " . port_num . "."
+    let s:browsersync_counter += 1
 endfunction
 
+command! StartBrowserSync call StartBrowserSync()
+command! -nargs=1 StartBrowserSyncOnPort call StartBrowserSyncOnPort(<f-args>)
+
+if executable('pkill')
 function! KillBrowserSync()
     let port = systemlist("pgrep -f 'browser-sync'")[0]
     if empty(port)
@@ -28,29 +36,41 @@ function! KillBrowserSync()
         call system(cmd)
         echo "BrowserSync server on port 3000 terminated."
     endif
+    let s:browsersync_counter -= 1
 endfunction
 
 function! KillBrowserSyncOnPort(port)
     let cmd = "pgrep -f 'browser-sync.*--port=" . a:port . "' | xargs -r kill"
     call system(cmd)
     echo "BrowserSync server on port " . a:port . " terminated."
+    let s:browsersync_counter -= 1
 endfunction
 
 function! KillAllBrowserSyncInstances()
     let cmd = "pkill -f 'browser-sync'"
     call system(cmd)
+    let s:browsersync_counter = 0
 endfunction
+
+command! KillBrowserSync call KillBrowserSync()
+command! -nargs=1 KillBrowserSyncOnPort call KillBrowserSyncOnPort(<f-args>)
 
 augroup BrowserSyncKill
     autocmd!
-    autocmd VimLeave * call KillAllBrowserSyncInstances()
+    autocmd VimLeave * if s:browsersync_counter > 0 | call KillAllBrowserSyncInstances() | endif
 augroup END
+endif
+endif
 
 " Live-Server
+if executable('live-server')
+let s:livebrowser_counter = 0
+
 function! StartLiveServer()
     let cmd = "live-server &"
     call system(cmd)
     echo "Live server started in the background."
+    let s:livebrowser_counter += 1
 endfunction
 
 function! StartLiveServerOnPort(port)
@@ -58,8 +78,14 @@ function! StartLiveServerOnPort(port)
     let cmd = "live-server --port=" . port_num . "&"
     call system(cmd)
     echo "Live Server started in the background on port " . port_num . "."
+    let s:livebrowser_counter += 1
 endfunction
 
+" Call Commands
+command! StartLiveServer call StartLiveServer()
+command! -nargs=1 StartLiveServerOnPort call StartLiveServerOnPort(<f-args>)
+
+if executable('pkill')
 function! KillLiveServer()
     let port = systemlist("pgrep -f 'live-server'")[0]
     if empty(port)
@@ -69,30 +95,28 @@ function! KillLiveServer()
         call system(cmd)
         echo "Live Server on port 8080 terminated."
     endif
+    if s:livebrowser_counter >= 0 | let s:livebrowser_counter -= 1 | endif
 endfunction
 
 function! KillLiveServerOnPort(port)
     let cmd = "pgrep -f 'live-server.*--port=" . a:port . "' | xargs -r kill"
     call system(cmd)
     echo "Live Server on port " . a:port . " terminated."
+    if s:livebrowser_counter >= 0 | let s:livebrowser_counter -= 1 | endif
 endfunction
 
 function! KillAllLiveServerInstances()
     let cmd = "pkill -f 'live-server'"
     call system(cmd)
+    let s:livebrowser_counter = 0
 endfunction
+
+command! KillLiveServer call KillLiveServer()
+command! -nargs=1 KillLiveServerOnPort call KillLiveServerOnPort(<f-args>)
 
 augroup LiveServerKill
     autocmd!
-    autocmd VimLeave * call KillAllLiveServerInstances()
+    autocmd VimLeave * if s:browsersync_counter > 0 | call KillAllLiveServerInstances() | endif
 augroup END
-
-" Call Commands
-command! StartBrowserSync call StartBrowserSync()
-command! StartLiveServer call StartLiveServer()
-command! -nargs=1 StartBrowserSyncOnPort call StartBrowserSyncOnPort(<f-args>)
-command! -nargs=1 StartLiveServerOnPort call StartLiveServerOnPort(<f-args>)
-command! KillBrowserSync call KillBrowserSync()
-command! KillLiveServer call KillLiveServer()
-command! -nargs=1 KillBrowserSyncOnPort call KillBrowserSyncOnPort(<f-args>)
-command! -nargs=1 KillLiveServerOnPort call KillLiveServerOnPort(<f-args>)
+endif
+endif

--- a/plugin/vim-live-server.vim
+++ b/plugin/vim-live-server.vim
@@ -36,14 +36,14 @@ function! KillBrowserSync()
         call system(cmd)
         echo "BrowserSync server on port 3000 terminated."
     endif
-    if s:browsersync_counter >= 0 | let s:browsersync_counter -= 1 | endif
+    if s:browsersync_counter > 0 | let s:browsersync_counter -= 1 | endif
 endfunction
 
 function! KillBrowserSyncOnPort(port)
     let cmd = "pgrep -f 'browser-sync.*--port=" . a:port . "' | xargs -r kill"
     call system(cmd)
     echo "BrowserSync server on port " . a:port . " terminated."
-    if s:browsersync_counter >= 0 | let s:browsersync_counter -= 1 | endif
+    if s:browsersync_counter > 0 | let s:browsersync_counter -= 1 | endif
 endfunction
 
 function! KillAllBrowserSyncInstances()
@@ -95,14 +95,14 @@ function! KillLiveServer()
         call system(cmd)
         echo "Live Server on port 8080 terminated."
     endif
-    if s:livebrowser_counter >= 0 | let s:livebrowser_counter -= 1 | endif
+    if s:livebrowser_counter > 0 | let s:livebrowser_counter -= 1 | endif
 endfunction
 
 function! KillLiveServerOnPort(port)
     let cmd = "pgrep -f 'live-server.*--port=" . a:port . "' | xargs -r kill"
     call system(cmd)
     echo "Live Server on port " . a:port . " terminated."
-    if s:livebrowser_counter >= 0 | let s:livebrowser_counter -= 1 | endif
+    if s:livebrowser_counter > 0 | let s:livebrowser_counter -= 1 | endif
 endfunction
 
 function! KillAllLiveServerInstances()


### PR DESCRIPTION
otherwise vim might hang for example on msys2 that comes without pkill (but needs to be installed with pacman -S procps-ng)

Thank you for the plug-in!